### PR TITLE
Document core domain skeleton

### DIFF
--- a/docs/adr/ADR-0008-core-domain-skeleton.md
+++ b/docs/adr/ADR-0008-core-domain-skeleton.md
@@ -1,0 +1,25 @@
+# ADR-0008: Core Domain Skeleton
+
+- Title: Core Domain Skeleton
+- Status: Accepted
+
+## Context
+
+InfraLynx needs a stable platform-level core before domain modules such as IPAM and DCIM can be introduced. Authentication, RBAC, tenants, tagging, statuses, and audit logging are foundational capabilities, but implementing full runtime services too early would create avoidable coupling.
+
+## Decision
+
+InfraLynx will introduce three focused packages:
+
+- `@infralynx/core-domain`
+- `@infralynx/auth`
+- `@infralynx/audit`
+
+These packages will define typed entities, baseline service helpers, and package boundaries without introducing persistence, provider integrations, or transport-specific behavior.
+
+## Consequences
+
+- future domains can depend on stable core contracts early
+- authentication and authorization remain modular instead of leaking into app runtimes
+- audit logging starts as an append-only contract, not an implementation-specific log store
+- richer identity, policy, and tenant workflows are deferred to later chunks

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -29,6 +29,12 @@ The platform repository begins as a monorepo with explicit runtime separation:
 
 Shared packages are limited to configuration, core domain contracts, and low-coupling utilities so teams can scale without collapsing boundaries between runtimes.
 
+The foundational platform packages now also include:
+
+- `@infralynx/core-domain`
+- `@infralynx/auth`
+- `@infralynx/audit`
+
 ## Database Compatibility Direction
 
 InfraLynx must support:

--- a/docs/engineering/auth-model.md
+++ b/docs/engineering/auth-model.md
@@ -1,0 +1,31 @@
+# Authentication Model
+
+InfraLynx authentication is modeled as an identity and session concern separate from authorization.
+
+## Core Concepts
+
+- identity: who the subject is
+- authentication method: how the subject proved identity
+- session: the issued runtime credential window
+- tenant context: which tenant boundary the subject belongs to
+
+## Supported Authentication Methods
+
+- password
+- SSO
+- API token
+- service account
+
+## Design Direction
+
+- authentication should produce a normalized identity object
+- downstream services should consume identity plus tenant context, not provider-specific claims
+- session issuance and expiration must stay explicit and auditable
+- provider integrations will be adapters layered on top of this model later
+
+## Exclusions in This Chunk
+
+- no password storage implementation
+- no token signing implementation
+- no SSO provider integration
+- no user-management UI

--- a/docs/engineering/core-domain-architecture.md
+++ b/docs/engineering/core-domain-architecture.md
@@ -1,0 +1,39 @@
+# Core Domain Architecture
+
+The core platform layer defines the shared business contracts that other InfraLynx domains depend on before DCIM, IPAM, or automation-specific models are introduced.
+
+## Scope
+
+The initial core-domain skeleton covers:
+
+- tenants
+- tagging
+- statuses
+- permissions
+- roles
+
+These contracts stay intentionally small so later domains can depend on stable identifiers and service boundaries without inheriting application-specific logic too early.
+
+## Package Boundaries
+
+- `@infralynx/core-domain` owns base entities and RBAC-oriented contracts
+- `@infralynx/auth` owns identity, session, and authorization decision scaffolds
+- `@infralynx/audit` owns append-only audit event contracts and summaries
+
+## Design Rules
+
+- core entities must remain persistence-agnostic
+- authorization contracts belong to shared core packages, not app runtimes
+- package boundaries should reflect ownership, not convenience reuse
+- audit recording is append-only by design and should not become a mutable activity log
+
+## Early Service Scaffolds
+
+The current skeleton provides:
+
+- tenant directory indexing
+- role indexing
+- access-decision evaluation from role assignments
+- audit record construction and summarization
+
+These are baseline service helpers only, not final runtime implementations.

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -8,6 +8,9 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `apps/api` for API delivery and request orchestration
 - `apps/worker` for asynchronous processing and integrations
 - `packages/config` for shared configuration metadata and helpers
+- `packages/core-domain` for base entities, statuses, permissions, and roles
+- `packages/auth` for identity, session, and authorization scaffolds
+- `packages/audit` for audit record contracts
 - `packages/domain-core` for core platform boundaries and domain contracts
 - `packages/shared` for reusable utilities with low coupling
 - `tests` for shared testing structure
@@ -25,5 +28,6 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 
 - `apps/*` consume packages and compose runtime behavior
 - `packages/domain-core` defines platform-level boundaries and contracts
+- `packages/core-domain`, `packages/auth`, and `packages/audit` define reusable platform service contracts
 - `packages/shared` must not become an unreviewed dumping ground
 - database-engine specifics belong under `migrations/*`, not mixed into app code

--- a/docs/engineering/rbac-model.md
+++ b/docs/engineering/rbac-model.md
@@ -1,0 +1,31 @@
+# RBAC Model
+
+InfraLynx uses RBAC to keep authorization predictable across product domains.
+
+## Model
+
+- permission: action allowed on a resource
+- role: named bundle of permissions
+- assignment: roles granted to an authenticated identity
+- access decision: allow or deny result for a requested permission
+
+## Early Baseline
+
+The current skeleton defines:
+
+- permission identifiers like `tenant:read`
+- role identifiers like `platform-admin`
+- authorization evaluation based on assigned role IDs
+
+## Design Rules
+
+- roles must remain business-readable
+- permissions must stay stable and machine-oriented
+- application code should ask for a permission decision, not inspect role names directly
+- domain-specific permissions will extend the core set later rather than replacing it
+
+## Risks to Control
+
+- role explosion from overly specific roles
+- permission names tied too tightly to UI screens
+- hidden authorization logic outside shared policy evaluation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,9 @@ nav:
       - Architecture: engineering/architecture.md
       - Platform Repository: engineering/platform-repository.md
       - Database Abstraction: engineering/database-abstraction.md
+      - Core Domain Architecture: engineering/core-domain-architecture.md
+      - Authentication Model: engineering/auth-model.md
+      - RBAC Model: engineering/rbac-model.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
@@ -60,6 +63,7 @@ nav:
       - ADR-0005 Platform Monorepo Foundation: adr/ADR-0005-platform-monorepo-foundation.md
       - ADR-0006 CI Baseline: adr/ADR-0006-ci-baseline.md
       - ADR-0007 Database Abstraction Design: adr/ADR-0007-database-abstraction-design.md
+      - ADR-0008 Core Domain Skeleton: adr/ADR-0008-core-domain-skeleton.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document the core domain architecture baseline
- add authentication and RBAC model pages
- record ADR-0008 for the core domain skeleton

## Validation
- python -m mkdocs build --strict