### PR TITLE
Document IPAM domain design

### DIFF
--- a/docs/adr/ADR-0009-ipam-domain-design.md
+++ b/docs/adr/ADR-0009-ipam-domain-design.md
@@ -1,0 +1,25 @@
+# ADR-0009: IPAM Domain Design
+
+- Title: IPAM Domain Design
+- Status: Accepted
+
+## Context
+
+InfraLynx needs a stable IPAM contract before DCIM, networking, and runtime data services are implemented. VRFs, prefixes, IP addresses, and VLANs are foundational entities that must share consistent relationships and validation rules across the platform.
+
+## Decision
+
+InfraLynx will introduce an `@infralynx/ipam-domain` package that defines:
+
+- VRF, prefix, IP address, and VLAN models
+- baseline validation helpers
+- allocation-policy helpers for child-prefix eligibility
+
+The first chunk remains at the domain-contract level and defers full address arithmetic, persistence, and allocator implementation.
+
+## Consequences
+
+- later IPAM work can build on stable domain contracts
+- validation rules become explicit and testable before storage is implemented
+- allocation logic remains visible without prematurely committing to a complex allocator
+- richer prefix containment and utilization logic must be added in later chunks

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -34,6 +34,7 @@ The foundational platform packages now also include:
 - `@infralynx/core-domain`
 - `@infralynx/auth`
 - `@infralynx/audit`
+- `@infralynx/ipam-domain`
 
 ## Database Compatibility Direction
 

--- a/docs/engineering/ipam-allocation.md
+++ b/docs/engineering/ipam-allocation.md
@@ -1,0 +1,35 @@
+# IPAM Allocation Logic
+
+InfraLynx starts with an explicit allocation-policy model before implementing a runtime allocator.
+
+## Allocation Modes
+
+- `hierarchical`
+- `pool`
+- `static`
+
+## Baseline Logic
+
+The current design treats allocation as valid when:
+
+- parent and child prefixes use the same address family
+- parent and child prefixes stay within the same VRF
+- the child prefix is more specific than the parent prefix
+- the parent prefix is active
+
+## Design Constraints
+
+- allocation rules must be deterministic and auditable
+- VRF boundaries must never be crossed by allocator logic
+- later host-allocation logic must be derived from prefix contracts, not embedded in app runtimes
+- pool behavior should be added by extending `allocationMode`, not by creating parallel ad hoc workflows
+
+## Next Implementation Phase
+
+Later IPAM chunks should add:
+
+- overlap detection
+- prefix utilization metrics
+- host allocation from parent pools
+- reserved-range handling
+- database persistence and query boundaries

--- a/docs/engineering/ipam-data-model.md
+++ b/docs/engineering/ipam-data-model.md
@@ -1,0 +1,63 @@
+# IPAM Data Model
+
+The InfraLynx IPAM baseline starts with four core entities:
+
+- VRF
+- prefix
+- IP address
+- VLAN
+
+These are modeled as transport-agnostic contracts inside `@infralynx/ipam-domain`.
+
+## Entity Relationships
+
+- a VRF scopes prefixes and IP addresses
+- a prefix can optionally belong to a tenant
+- a prefix can optionally reference a VLAN for network segmentation context
+- an IP address belongs to at most one prefix
+- a VLAN can be referenced by many prefixes
+
+## Core Models
+
+### VRF
+
+- `id`
+- `name`
+- `rd`
+- `tenantId`
+
+### Prefix
+
+- `id`
+- `vrfId`
+- `cidr`
+- `family`
+- `status`
+- `allocationMode`
+- `tenantId`
+- `vlanId`
+
+### IP Address
+
+- `id`
+- `vrfId`
+- `address`
+- `family`
+- `status`
+- `role`
+- `prefixId`
+
+### VLAN
+
+- `id`
+- `vlanId`
+- `name`
+- `status`
+- `tenantId`
+
+## Relationship Rules
+
+- VRF identity must stay stable across all attached prefixes and IP addresses
+- IP address family must match the family of the containing prefix
+- prefixes and VLAN references are optional but must remain explicit when present
+- allocation decisions must operate within a single VRF boundary

--- a/docs/engineering/ipam-validation.md
+++ b/docs/engineering/ipam-validation.md
@@ -1,0 +1,26 @@
+# IPAM Validation Rules
+
+The initial IPAM skeleton validates baseline correctness without implementing full network arithmetic.
+
+## Current Rules
+
+- VLAN IDs must be integers in the range `1-4094`
+- route distinguishers must use `ASN:VALUE` shape when present
+- prefixes must use CIDR notation
+- prefix lengths must stay inside family limits:
+  - IPv4: `0-32`
+  - IPv6: `0-128`
+- IP addresses must include host prefix length notation
+- child prefix requests must remain in the same family and VRF as the parent prefix
+- child prefixes must be more specific than the parent prefix
+- allocation can only occur from active parent prefixes
+
+## Deferred Validation
+
+The following are intentionally deferred until later implementation chunks:
+
+- full IPv4/IPv6 containment math
+- overlap detection across sibling prefixes
+- usable-host calculations
+- gateway reservation strategy
+- duplicate address detection across persisted records

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -29,5 +29,6 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `apps/*` consume packages and compose runtime behavior
 - `packages/domain-core` defines platform-level boundaries and contracts
 - `packages/core-domain`, `packages/auth`, and `packages/audit` define reusable platform service contracts
+- `packages/ipam-domain` defines VRF, prefix, IP address, VLAN, and allocation contracts
 - `packages/shared` must not become an unreviewed dumping ground
 - database-engine specifics belong under `migrations/*`, not mixed into app code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
       - Core Domain Architecture: engineering/core-domain-architecture.md
       - Authentication Model: engineering/auth-model.md
       - RBAC Model: engineering/rbac-model.md
+      - IPAM Data Model: engineering/ipam-data-model.md
+      - IPAM Validation Rules: engineering/ipam-validation.md
+      - IPAM Allocation Logic: engineering/ipam-allocation.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
@@ -64,6 +67,7 @@ nav:
       - ADR-0006 CI Baseline: adr/ADR-0006-ci-baseline.md
       - ADR-0007 Database Abstraction Design: adr/ADR-0007-database-abstraction-design.md
       - ADR-0008 Core Domain Skeleton: adr/ADR-0008-core-domain-skeleton.md
+      - ADR-0009 IPAM Domain Design: adr/ADR-0009-ipam-domain-design.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document the IPAM data model
- add validation rule guidance and allocation logic notes
- record ADR-0009 for IPAM domain design

## Validation
- python -m mkdocs build --strict