### PR TITLE
Chunk 12: document network modeling engine

### DIFF
--- a/docs/adr/ADR-0013-network-modeling-engine.md
+++ b/docs/adr/ADR-0013-network-modeling-engine.md
@@ -1,0 +1,38 @@
+# ADR-0013 Network Modeling Engine
+
+## Title
+
+Network Modeling Engine
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx now has core, IPAM, DCIM, and cross-domain binding contracts. The platform needs a deterministic way to model topology relationships and trace simple paths without jumping directly into a full graph engine.
+
+## Decision
+
+InfraLynx will introduce topology and path-tracing helpers inside `@infralynx/network-domain`.
+
+The initial implementation will:
+
+- model topology as explicit directed edges
+- distinguish L2, L3, VLAN, and cable relationships by edge kind
+- use breadth-first traversal with stable ordering
+- bound traversal with a caller-provided depth limit
+
+## Consequences
+
+Benefits:
+
+- deterministic and testable topology behavior
+- clear separation between physical, VLAN, and routed relationships
+- lower implementation risk than introducing a full graph platform early
+
+Tradeoffs:
+
+- limited support for advanced routing scenarios
+- no weighted path selection yet
+- future scaling work will be required for very large topologies

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -39,6 +39,11 @@ The foundational platform packages now also include:
 - `@infralynx/ui`
 - `@infralynx/network-domain`
 
+The networking package is now split into two distinct concerns:
+
+- cross-domain binding contracts
+- deterministic topology and path-tracing helpers
+
 ## Database Compatibility Direction
 
 InfraLynx must support:

--- a/docs/engineering/l2-vs-l3-handling.md
+++ b/docs/engineering/l2-vs-l3-handling.md
@@ -1,0 +1,36 @@
+# L2 vs L3 Handling
+
+InfraLynx distinguishes layer 2 and layer 3 relationships explicitly so topology consumers can reason about switching and routing behavior without guessing intent from raw connections.
+
+## Layer 2
+
+Layer 2 relationships represent adjacency and propagation at the switching layer.
+
+- `cable-link` captures a physical connection
+- `l2-adjacency` captures a switching adjacency between interfaces
+- `vlan-propagation` captures VLAN movement across an eligible link or interface boundary
+
+## Layer 3
+
+Layer 3 relationships represent addressing and routed adjacency.
+
+- `l3-adjacency` links an interface or routed hop to an IP-level node
+- VRF, prefix, and IP hierarchy remain explicit and ID-based
+
+## Separation Rules
+
+- L2 edges do not imply L3 reachability
+- L3 edges do not imply physical adjacency
+- VLAN membership does not embed interface objects
+- routing and switching relationships can coexist on the same inventory objects
+
+## Example Scenario
+
+An interface can:
+
+- participate in a `cable-link`
+- form an `l2-adjacency`
+- propagate one or more VLANs
+- bind to one or more IP addresses through separate `l3-adjacency` edges
+
+This keeps physical, broadcast, and routed semantics separate while still allowing end-to-end tracing.

--- a/docs/engineering/path-tracing-logic.md
+++ b/docs/engineering/path-tracing-logic.md
@@ -1,0 +1,37 @@
+# Path Tracing Logic
+
+The first InfraLynx path-tracing engine is intentionally deterministic and breadth-first. Its purpose is to define the traversal contract, not to solve every networking scenario in the first iteration.
+
+## Trace Inputs
+
+- start node ID
+- target node ID
+- allowed edge kinds
+- maximum depth
+
+## Trace Behavior
+
+1. Build an adjacency index from topology edges.
+2. Sort outbound edges into a stable order.
+3. Traverse with breadth-first search.
+4. Stop when the target node is reached or the depth limit is exceeded.
+
+## Determinism Rules
+
+- the same edge set must produce the same traversal order
+- visited node tracking prevents loops
+- depth limiting bounds recursion and runtime cost
+- edge-kind filters let callers trace only the layers they care about
+
+## Near-Term Use Cases
+
+- validate direct L2 and L3 service reachability
+- prove that an interface-to-address binding can be traversed
+- document expected behavior for later topology and path APIs
+
+## Deferred Work
+
+- weighted path selection
+- multi-path tracing
+- policy-based routing interpretation
+- large-topology performance indexing

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -31,7 +31,7 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `packages/core-domain`, `packages/auth`, and `packages/audit` define reusable platform service contracts
 - `packages/ipam-domain` defines VRF, prefix, IP address, VLAN, and allocation contracts
 - `packages/dcim-domain` defines site, rack, device, interface, power, and cable contracts
-- `packages/network-domain` defines cross-domain bindings between DCIM, IPAM, and networking concerns
+- `packages/network-domain` defines cross-domain bindings, topology edges, and path-tracing helpers
 - `packages/ui` defines shell navigation, tokens, and shared UI contracts
 - `packages/shared` must not become an unreviewed dumping ground
 - database-engine specifics belong under `migrations/*`, not mixed into app code

--- a/docs/engineering/topology-model.md
+++ b/docs/engineering/topology-model.md
@@ -1,0 +1,34 @@
+# Topology Model
+
+InfraLynx models topology as explicit directed edges between stable IDs. The model stays deliberately small so it can support deterministic validation and tracing before a larger graph subsystem exists.
+
+## Node Classes
+
+- DCIM interfaces
+- IP addresses
+- prefixes
+- VLANs
+
+## Edge Classes
+
+- `l2-adjacency`
+- `l3-adjacency`
+- `vlan-propagation`
+- `cable-link`
+
+## Modeling Rules
+
+- edges always connect two distinct node IDs
+- edge kinds are explicit and never inferred from naming
+- metadata is supplemental and does not replace typed IDs
+- traversal order is deterministic and derived from stable edge sorting
+
+## Ownership
+
+- `dcim-domain` owns physical inventory identifiers
+- `ipam-domain` owns logical addressing identifiers
+- `network-domain` owns topology edges and traversal helpers
+
+## Current Boundaries
+
+The current model is a scaffold for validation and tracing. It does not yet implement large-topology indexing, path weighting, ECMP handling, or dynamic route computation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,9 @@ nav:
       - Cross-Domain Relationships: engineering/cross-domain-relationships.md
       - Cross-Domain Data Flows: engineering/cross-domain-flows.md
       - Cross-Domain Validation: engineering/cross-domain-validation.md
+      - Topology Model: engineering/topology-model.md
+      - Path Tracing Logic: engineering/path-tracing-logic.md
+      - L2 vs L3 Handling: engineering/l2-vs-l3-handling.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
@@ -78,6 +81,7 @@ nav:
       - ADR-0010 DCIM Domain Design: adr/ADR-0010-dcim-domain-design.md
       - ADR-0011 UI Shell Architecture: adr/ADR-0011-ui-shell-architecture.md
       - ADR-0012 Cross-Domain Integration Model: adr/ADR-0012-cross-domain-integration-model.md
+      - ADR-0013 Network Modeling Engine: adr/ADR-0013-network-modeling-engine.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- add topology model documentation
- add path tracing and L2/L3 handling guidance
- record ADR-0013 for the network modeling engine

## Validation
- python -m mkdocs build --strict