### PR TITLE
Chunk 10.5: Document media asset management core service

### DIFF
--- a/docs/adr/ADR-0020-media-asset-management-core-service.md
+++ b/docs/adr/ADR-0020-media-asset-management-core-service.md
@@ -1,0 +1,23 @@
+# ADR-0020: Media Asset Management Core Service
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx needs image and file support across multiple domains, but none of the domain models should become the owner of file storage or media metadata. Media handling must stay independent from the UI layer and must be capable of moving from local storage to cloud-backed storage later.
+
+## Decision
+
+InfraLynx will implement media management as a standalone core service with:
+
+- explicit media metadata records
+- explicit media-link records
+- local-first object storage behind a storage adapter boundary
+- file-backed metadata persistence as the initial operational baseline
+- tenant-aware RBAC enforcement on upload and retrieval
+
+## Consequences
+
+Domains can reference media through links without embedding file concerns. The current persistence approach is operational but temporary, so later chunks can replace local metadata storage and local object storage without breaking the contract shape.

--- a/docs/api/media.md
+++ b/docs/api/media.md
@@ -1,0 +1,47 @@
+# Media API
+
+The media API provides upload, metadata lookup, linked-object lookup, and binary retrieval.
+
+## Endpoints
+
+- `POST /api/media/upload`
+- `GET /api/media/{mediaId}`
+- `GET /api/media/{mediaId}/content`
+- `GET /api/media/linked?objectType=...&objectId=...&tenantId=...`
+
+## Identity headers
+
+- `X-InfraLynx-Actor-Id`
+- `X-InfraLynx-Tenant-Id`
+- `X-InfraLynx-Role-Ids`
+
+## Upload payload
+
+```json
+{
+  "filename": "rack-a1.png",
+  "contentType": "image/png",
+  "contentBase64": "iVBORw0KGgoAAA...",
+  "tenantId": "tenant-ops",
+  "associations": [
+    { "objectType": "rack", "objectId": "rack-a1" }
+  ]
+}
+```
+
+## Response shape
+
+Metadata responses include:
+
+- media identifiers
+- sanitized filename
+- content type and size
+- tenant ownership
+- association links
+- content URL
+
+## Contract notes
+
+- media bytes are never embedded in metadata responses
+- link lookups are tenant-scoped
+- upload and retrieval permissions are enforced separately

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface has not been implemented yet. This section establishes the documentation framework so later domain work can add contract details without reworking structure.
+The API surface now includes baseline read endpoints for shell-facing data and a standalone media API for upload and retrieval. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
 
 ## Documentation Rules
 

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -38,6 +38,8 @@ The foundational platform packages now also include:
 - `@infralynx/dcim-domain`
 - `@infralynx/ui`
 - `@infralynx/network-domain`
+- `@infralynx/media-core`
+- `@infralynx/media-storage`
 
 The networking package is now split into two distinct concerns:
 
@@ -79,6 +81,12 @@ The UI layer now also includes a shared navigation system:
 - route, breadcrumb, and context-link contracts in `@infralynx/ui`
 - persistent shell layout and navigation rendering in `apps/web`
 - explicit domain-to-route mapping for stable cross-domain movement
+
+The core platform now also includes a standalone media service:
+
+- metadata, link, and RBAC helpers in `@infralynx/media-core`
+- local-first object storage adapters in `@infralynx/media-storage`
+- upload and retrieval endpoints in `apps/api`
 
 ## Database Compatibility Direction
 

--- a/docs/engineering/core-domain-architecture.md
+++ b/docs/engineering/core-domain-architecture.md
@@ -11,6 +11,7 @@ The initial core-domain skeleton covers:
 - statuses
 - permissions
 - roles
+- media linking support
 
 These contracts stay intentionally small so later domains can depend on stable identifiers and service boundaries without inheriting application-specific logic too early.
 
@@ -19,6 +20,7 @@ These contracts stay intentionally small so later domains can depend on stable i
 - `@infralynx/core-domain` owns base entities and RBAC-oriented contracts
 - `@infralynx/auth` owns identity, session, and authorization decision scaffolds
 - `@infralynx/audit` owns append-only audit event contracts and summaries
+- `@infralynx/media-core` owns media metadata, linking, validation, and access-control helpers
 
 ## Design Rules
 

--- a/docs/engineering/media-object-association.md
+++ b/docs/engineering/media-object-association.md
@@ -1,0 +1,31 @@
+# Media Object Association Model
+
+InfraLynx media relationships are modeled through explicit links.
+
+## Media record
+
+- `id`
+- `filename`
+- `content_type`
+- `size`
+- `storage_path`
+- `tenant_id`
+- `created_by`
+- `created_at`
+
+## Media link record
+
+- `media_id`
+- `object_type`
+- `object_id`
+
+## Supported object types
+
+- tenant
+- device
+- rack
+- site
+
+## Design rule
+
+Domains reference media through links. They do not store direct media fields or embedded file metadata in their own contract models.

--- a/docs/engineering/media-security-validation.md
+++ b/docs/engineering/media-security-validation.md
@@ -1,0 +1,27 @@
+# Media Security And Validation Rules
+
+InfraLynx media upload handling must reject unsafe input before persistence.
+
+## Validation baseline
+
+- filename is sanitized before storage
+- content type must be on the allow list
+- file size must be positive and under the configured maximum
+- object links must use supported object types and non-empty IDs
+
+## Current allow list
+
+- `image/png`
+- `image/jpeg`
+- `image/gif`
+- `image/webp`
+- `application/pdf`
+- `text/plain`
+
+## Access control rules
+
+- media endpoints require actor, tenant, and role headers
+- `media:write` is required for upload
+- `media:assign` is required when creating object links
+- `media:read` is required for metadata and content retrieval
+- tenant isolation blocks cross-tenant access even when a record exists

--- a/docs/engineering/media-system-architecture.md
+++ b/docs/engineering/media-system-architecture.md
@@ -1,0 +1,25 @@
+# Media System Architecture
+
+InfraLynx media handling is a core platform service, not a domain-owned feature.
+
+## Service boundaries
+
+- `@infralynx/media-core` owns metadata, object-linking, validation, and RBAC-aware access decisions
+- `@infralynx/media-storage` owns object storage adapters
+- `apps/api/src/media` owns HTTP transport, header-based identity extraction, and endpoint responses
+
+## Design rules
+
+- media fields are not embedded into domain entities
+- file bytes are stored outside the database layer
+- media-to-object relationships use an explicit linking model
+- tenant boundaries apply to both metadata access and object retrieval
+
+## Current implementation
+
+The current baseline uses:
+
+- file-backed metadata persistence for operational bootstrap
+- local filesystem object storage
+- explicit media and media-link records
+- reusable storage and metadata seams for later SQL and cloud adapters

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -11,6 +11,8 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `packages/core-domain` for base entities, statuses, permissions, and roles
 - `packages/auth` for identity, session, and authorization scaffolds
 - `packages/audit` for audit record contracts
+- `packages/media-core` for media metadata, validation, linking, and access-control helpers
+- `packages/media-storage` for filesystem and future cloud-backed object storage adapters
 - `packages/domain-core` for core platform boundaries and domain contracts
 - `packages/shared` for reusable utilities with low coupling
 - `tests` for shared testing structure
@@ -29,6 +31,8 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `apps/*` consume packages and compose runtime behavior
 - `packages/domain-core` defines platform-level boundaries and contracts
 - `packages/core-domain`, `packages/auth`, and `packages/audit` define reusable platform service contracts
+- `packages/media-core` defines media metadata, linking, and tenant-aware access contracts
+- `packages/media-storage` defines object storage adapters and must not own metadata policy
 - `packages/ipam-domain` defines VRF, prefix, IP address, VLAN, and allocation contracts
 - `packages/dcim-domain` defines site, rack, device, interface, power, and cable contracts
 - `packages/network-domain` defines cross-domain bindings, topology edges, and path-tracing helpers
@@ -94,3 +98,13 @@ Navigation is split across three ownership areas:
 - `apps/web/src/components/navigation` for sidebar, breadcrumb, and context navigation rendering
 
 This keeps navigation rules centralized and prevents individual pages from inventing inconsistent hierarchy behavior.
+
+## Media Service Layer
+
+Media handling is split across three ownership areas:
+
+- `packages/media-core` for metadata, links, validation, and RBAC-aware access checks
+- `packages/media-storage` for storage adapters
+- `apps/api/src/media` for HTTP upload and retrieval endpoints
+
+This keeps file handling independent from UI code and prevents domain models from owning file storage concerns.

--- a/docs/operations/media-storage-strategy.md
+++ b/docs/operations/media-storage-strategy.md
@@ -1,0 +1,19 @@
+# Media Storage Strategy
+
+InfraLynx starts with local filesystem storage and a file-backed metadata repository, but the service boundaries are intentionally cloud-ready.
+
+## Current bootstrap strategy
+
+- object bytes stored on local disk
+- metadata stored in a file-backed repository
+- storage paths scoped by tenant and media ID
+
+## Future adapter direction
+
+- S3-compatible object storage
+- Azure Blob storage
+- SQL-backed metadata persistence
+
+## Migration rule
+
+Storage adapters must preserve the same media and media-link contract shape so upload, retrieval, and tenant-isolation behavior do not change when backends are swapped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,12 +76,17 @@ nav:
       - Search Query Patterns: engineering/search-query-patterns.md
       - Navigation Structure: engineering/navigation-structure.md
       - Page Hierarchy Rules: engineering/page-hierarchy-rules.md
+      - Media System Architecture: engineering/media-system-architecture.md
+      - Media Security And Validation: engineering/media-security-validation.md
+      - Media Object Association Model: engineering/media-object-association.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
       - Database Testing: operations/database-testing.md
+      - Media Storage Strategy: operations/media-storage-strategy.md
   - API:
       - Overview: api/overview.md
+      - Media API: api/media.md
   - Releases:
       - Release Notes: releases/index.md
   - ADR:
@@ -104,6 +109,7 @@ nav:
       - ADR-0017 IPAM Tree Visualization: adr/ADR-0017-ipam-tree-visualization.md
       - ADR-0018 Search and Filtering System: adr/ADR-0018-search-and-filtering-system.md
       - ADR-0019 Global Navigation Refinement: adr/ADR-0019-global-navigation-refinement.md
+      - ADR-0020 Media Asset Management Core Service: adr/ADR-0020-media-asset-management-core-service.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document the media system architecture, storage strategy, security rules, object association model, and API usage
- record ADR-0020 for the retroactive core media service insertion
- update architecture and repository docs to include the media service boundary

## Validation
- python -m mkdocs build --strict