### PR TITLE
Chunk 19: Document job engine baseline

### DIFF
--- a/docs/adr/ADR-0021-job-engine-background-task-system.md
+++ b/docs/adr/ADR-0021-job-engine-background-task-system.md
@@ -1,0 +1,24 @@
+# ADR-0021: Job Engine Background Task System
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx needs asynchronous execution for imports, exports, integrations, and other long-running platform operations. This work must be isolated from API request handling and must avoid early lock-in to a specific queue vendor.
+
+## Decision
+
+InfraLynx will introduce a standalone job engine with:
+
+- explicit job and job-log records
+- a queue abstraction separated from worker execution
+- API-driven job creation and status retrieval
+- dedicated worker processing
+- bounded retry handling and explicit failure transitions
+- audit-aware lifecycle summaries
+
+## Consequences
+
+Background processing is now a first-class platform capability. The initial file-backed queue implementation is suitable for bootstrap execution and testing, while later chunks can replace the storage and queue backend without breaking the core lifecycle contract.

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -1,0 +1,40 @@
+# Jobs API
+
+The jobs API provides a baseline asynchronous execution surface for background work.
+
+## Endpoints
+
+- `POST /api/jobs`
+- `GET /api/jobs`
+- `GET /api/jobs/{jobId}`
+- `GET /api/jobs/{jobId}/logs`
+
+## Headers
+
+- `X-InfraLynx-Actor-Id`
+- `X-InfraLynx-Role-Ids`
+- `X-InfraLynx-Tenant-Id`
+
+## Permission model
+
+- `job:write` is required to create jobs
+- `job:read` is required to read job records or job logs
+
+## Request shape
+
+`POST /api/jobs` accepts:
+
+- `type`: job type identifier
+- `payload`: JSON object payload
+- `createdBy`: optional explicit creator override
+- `retryPolicy`: optional retry policy override
+
+## Response shape
+
+Job responses include:
+
+- job metadata
+- current status
+- retry count
+- current result payload
+- associated job logs for detailed inspection

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface now includes baseline read endpoints for shell-facing data and a standalone media API for upload and retrieval. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
+The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, and a jobs API for asynchronous background execution. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
 
 ## Documentation Rules
 

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -88,6 +88,13 @@ The core platform now also includes a standalone media service:
 - local-first object storage adapters in `@infralynx/media-storage`
 - upload and retrieval endpoints in `apps/api`
 
+The core platform now also includes a standalone job engine:
+
+- lifecycle and retry contracts in `@infralynx/job-core`
+- queue persistence and job leasing in `@infralynx/job-queue`
+- job creation and status endpoints in `apps/api`
+- asynchronous execution in `apps/worker`
+
 ## Database Compatibility Direction
 
 InfraLynx must support:

--- a/docs/engineering/job-lifecycle-model.md
+++ b/docs/engineering/job-lifecycle-model.md
@@ -1,0 +1,24 @@
+# Job Lifecycle Model
+
+InfraLynx jobs move through a bounded lifecycle.
+
+## Lifecycle states
+
+- `pending`: the job has been accepted and is waiting to be leased by a worker
+- `running`: a worker has leased the job and is currently executing it
+- `success`: execution completed successfully and produced a terminal result
+- `failed`: execution exhausted retry allowance or hit a terminal failure condition
+
+## Transition rules
+
+- API creation always starts at `pending`
+- worker leasing moves a job from `pending` to `running`
+- successful handler completion moves a job from `running` to `success`
+- handler failure either returns the job to `pending` for retry or moves it to `failed`
+
+## Retry accounting
+
+- every failed execution attempt increments `retryCount`
+- retry policy is explicit and attached to the job contract
+- jobs stop retrying when the retry cap is reached
+- terminal failure preserves the latest error message in the job result metadata

--- a/docs/engineering/job-system-architecture.md
+++ b/docs/engineering/job-system-architecture.md
@@ -1,0 +1,28 @@
+# Job System Architecture
+
+InfraLynx background execution is implemented as a standalone platform service.
+
+## Service boundaries
+
+- `@infralynx/job-core` owns job records, lifecycle transitions, retry policy, and job-log contracts
+- `@infralynx/job-queue` owns queue persistence and job leasing
+- `apps/api/src/jobs` owns HTTP job creation and status retrieval
+- `apps/worker` owns asynchronous job execution
+
+## Design rules
+
+- job execution is asynchronous and decoupled from API request latency
+- queue behavior is defined behind an abstraction boundary
+- workers operate on explicit leased jobs instead of scanning arbitrary domain state
+- job status and job logs are persisted separately from the HTTP transport
+- audit summaries are emitted alongside lifecycle transitions
+
+## Current implementation
+
+The current baseline uses:
+
+- file-backed queue state
+- process-safe file locking for queue mutation
+- explicit job and job-log records
+- worker-side handler registration by job type
+- deterministic status transitions for `pending`, `running`, `success`, and `failed`

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -13,6 +13,8 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `packages/audit` for audit record contracts
 - `packages/media-core` for media metadata, validation, linking, and access-control helpers
 - `packages/media-storage` for filesystem and future cloud-backed object storage adapters
+- `packages/job-core` for job lifecycle, retry, and job-log contracts
+- `packages/job-queue` for queue abstraction and file-backed queue persistence
 - `packages/domain-core` for core platform boundaries and domain contracts
 - `packages/shared` for reusable utilities with low coupling
 - `tests` for shared testing structure
@@ -108,3 +110,14 @@ Media handling is split across three ownership areas:
 - `apps/api/src/media` for HTTP upload and retrieval endpoints
 
 This keeps file handling independent from UI code and prevents domain models from owning file storage concerns.
+
+## Job Engine Layer
+
+Background work is split across four ownership areas:
+
+- `packages/job-core` for job records, state transitions, retry rules, and log contracts
+- `packages/job-queue` for queue storage and leasing behavior
+- `apps/api/src/jobs` for HTTP job creation and status retrieval
+- `apps/worker/src/jobs` for asynchronous processing and handler execution
+
+This keeps asynchronous execution separate from request handling and prevents domain packages from owning queue infrastructure.

--- a/docs/engineering/worker-model-design.md
+++ b/docs/engineering/worker-model-design.md
@@ -1,0 +1,28 @@
+# Worker Model Design
+
+InfraLynx workers are independent runtime processes that consume leased jobs from the shared queue abstraction.
+
+## Worker responsibilities
+
+- lease the next pending job
+- execute the registered handler for the job type
+- write lifecycle updates back to the queue store
+- append job logs for significant execution milestones
+- emit audit-friendly lifecycle summaries
+
+## Worker design rules
+
+- workers must treat every job as potentially retried
+- handlers must be idempotent
+- workers must not assume exclusive ownership beyond the active lease
+- missing handlers are treated as execution failures, not silent drops
+
+## Current baseline
+
+The current worker runtime provides:
+
+- single-cycle execution for deterministic tests and smoke checks
+- loop mode for continuous polling
+- handler registration by job type
+- bounded retry behavior
+- file-backed operational storage that can later be replaced behind the queue abstraction

--- a/docs/operations/job-retry-failure-rules.md
+++ b/docs/operations/job-retry-failure-rules.md
@@ -1,0 +1,23 @@
+# Job Retry And Failure Rules
+
+InfraLynx job execution must fail predictably and avoid uncontrolled retry loops.
+
+## Retry rules
+
+- retry limits are explicit and job-scoped
+- workers requeue failed jobs only while retry allowance remains
+- retry count is recorded on the job record
+- repeated failure does not create a duplicate job record
+
+## Failure rules
+
+- terminal failure moves the job to `failed`
+- failure details are stored in job result metadata
+- job logs must include the failure reason
+- audit summaries must record the final failure state
+
+## Operational rules
+
+- handlers must be designed for idempotent re-execution
+- failure alerting is a follow-up concern and remains outside the baseline runtime
+- queue backends must preserve job status and logs across worker restarts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,14 +79,19 @@ nav:
       - Media System Architecture: engineering/media-system-architecture.md
       - Media Security And Validation: engineering/media-security-validation.md
       - Media Object Association Model: engineering/media-object-association.md
+      - Job System Architecture: engineering/job-system-architecture.md
+      - Job Lifecycle Model: engineering/job-lifecycle-model.md
+      - Worker Model Design: engineering/worker-model-design.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
       - Database Testing: operations/database-testing.md
       - Media Storage Strategy: operations/media-storage-strategy.md
+      - Job Retry and Failure Rules: operations/job-retry-failure-rules.md
   - API:
       - Overview: api/overview.md
       - Media API: api/media.md
+      - Jobs API: api/jobs.md
   - Releases:
       - Release Notes: releases/index.md
   - ADR:
@@ -110,6 +115,7 @@ nav:
       - ADR-0018 Search and Filtering System: adr/ADR-0018-search-and-filtering-system.md
       - ADR-0019 Global Navigation Refinement: adr/ADR-0019-global-navigation-refinement.md
       - ADR-0020 Media Asset Management Core Service: adr/ADR-0020-media-asset-management-core-service.md
+      - ADR-0021 Job Engine Background Task System: adr/ADR-0021-job-engine-background-task-system.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document job system architecture and lifecycle
- add worker model and retry/failure operations guidance
- add jobs API documentation and ADR-0021

## Validation
- python -m mkdocs build --strict