### PR TITLE
Chunk 20: Document import export framework

### DIFF
--- a/docs/adr/ADR-0022-import-export-framework.md
+++ b/docs/adr/ADR-0022-import-export-framework.md
@@ -1,0 +1,24 @@
+# ADR-0022: Import Export Framework
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx needs a consistent transfer layer for CSV, JSON, and API-based bulk operations across multiple domains. The platform also needs dry-run validation, clean error reporting, and a path to asynchronous import execution through the job engine.
+
+## Decision
+
+InfraLynx will implement import and export as a standalone transfer service with:
+
+- dataset-owned transfer schemas
+- transport-neutral validation rules
+- explicit CSV, JSON, and API format support
+- synchronous commit for small valid payloads
+- job-engine-backed asynchronous import for larger batches
+- file-backed transfer state as the bootstrap runtime
+
+## Consequences
+
+Transfer behavior is now centralized and consistent across formats. The current implementation is operational for bootstrap workflows, while later chunks can replace file-backed transfer state with domain-aware persistence and richer rollback behavior without breaking the import/export contract shape.

--- a/docs/api/import-export.md
+++ b/docs/api/import-export.md
@@ -1,0 +1,40 @@
+# Import And Export API
+
+InfraLynx exposes standardized transfer endpoints for CSV, JSON, and API-based bulk operations.
+
+## Import endpoints
+
+- `POST /api/import/validate`
+- `POST /api/import/commit`
+
+## Export endpoints
+
+- `GET /api/export/{dataset}?format=json`
+- `GET /api/export/{dataset}?format=csv`
+- `GET /api/export/{dataset}?format=api`
+
+## Datasets
+
+- `tenants`
+- `prefixes`
+- `sites`
+
+## Request model
+
+Import requests include:
+
+- `dataset`
+- `format`
+- `dryRun`
+- `async`
+- `csvContent`, `jsonContent`, or `records`
+
+## Response model
+
+Responses include:
+
+- validation status
+- record count
+- structured errors and warnings
+- commit mode (`sync` or `async`)
+- queued job details for async imports

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, and a jobs API for asynchronous background execution. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
+The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, and import/export APIs for structured transfer workflows. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
 
 ## Documentation Rules
 

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -95,6 +95,12 @@ The core platform now also includes a standalone job engine:
 - job creation and status endpoints in `apps/api`
 - asynchronous execution in `apps/worker`
 
+The core platform now also includes a standalone transfer service:
+
+- format and schema validation in `@infralynx/data-transfer`
+- import and export endpoints in `apps/api`
+- job-engine-backed asynchronous import for larger payloads
+
 ## Database Compatibility Direction
 
 InfraLynx must support:

--- a/docs/engineering/data-mapping-guidelines.md
+++ b/docs/engineering/data-mapping-guidelines.md
@@ -1,0 +1,22 @@
+# Data Mapping Guidelines
+
+Import and export mappings stay explicit and dataset-owned.
+
+## Mapping rules
+
+- transfer records are not embedded into domain models
+- transport formats map onto stable transfer schemas first
+- API handlers must not bypass transfer validation
+- job payloads carry normalized transfer input, not raw multipart state
+
+## Dataset ownership
+
+- tenant transfer records map to core control-plane datasets
+- prefix transfer records map to IPAM addressing datasets
+- site transfer records map to DCIM location datasets
+
+## Consistency rules
+
+- field names remain consistent across CSV, JSON, and API formats
+- null-like optional values are normalized before commit
+- schema changes should be captured in ADRs or explicit API documentation updates

--- a/docs/engineering/import-export-formats.md
+++ b/docs/engineering/import-export-formats.md
@@ -1,0 +1,28 @@
+# Import And Export Formats
+
+InfraLynx import and export supports three transport formats:
+
+- CSV for operator-friendly tabular exchange
+- JSON for structured interchange
+- API for direct bulk-operation payloads
+
+## Dataset coverage
+
+The initial baseline supports:
+
+- `tenants`
+- `prefixes`
+- `sites`
+
+## Format rules
+
+- each dataset has a fixed schema across CSV, JSON, and API transport
+- CSV headers must match the documented field order exactly
+- JSON imports must be arrays of records
+- API imports accept normalized record arrays in the request body
+
+## Export rules
+
+- CSV exports produce one header row plus one row per record
+- JSON exports return the dataset record array
+- API exports return dataset metadata plus records

--- a/docs/engineering/import-export-validation.md
+++ b/docs/engineering/import-export-validation.md
@@ -1,0 +1,19 @@
+# Import And Export Validation Rules
+
+InfraLynx validates transfer payloads before commit.
+
+## Validation rules
+
+- dataset name must be recognized
+- format must be recognized
+- CSV headers must match the expected schema
+- required fields must be present
+- duplicate IDs are rejected
+- prefix records must pass CIDR validation before commit
+
+## Validation behavior
+
+- `POST /api/import/validate` never mutates transfer state
+- dry-run mode returns validation results without commit
+- invalid commits return structured row and field errors
+- large valid commits can be queued through the job engine

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -121,3 +121,13 @@ Background work is split across four ownership areas:
 - `apps/worker/src/jobs` for asynchronous processing and handler execution
 
 This keeps asynchronous execution separate from request handling and prevents domain packages from owning queue infrastructure.
+
+## Import And Export Layer
+
+Transfer behavior is split across three ownership areas:
+
+- `packages/data-transfer` for schema rules, parsing, validation, and file-backed transfer state
+- `apps/api/src/import` for validation, commit, and async-import endpoints
+- `apps/api/src/export` for format-aware export endpoints
+
+This keeps transport formats consistent across domains and prevents ad hoc import logic from leaking into runtime services.

--- a/docs/operations/import-export-error-handling.md
+++ b/docs/operations/import-export-error-handling.md
@@ -1,0 +1,23 @@
+# Import And Export Error Handling
+
+InfraLynx transfer failures must return actionable diagnostics without partial silent mutation.
+
+## Error handling rules
+
+- parse failures return document-level errors
+- row validation failures return row and field details
+- invalid commits do not mutate transfer state
+- dry-run mode returns the same validation model as commit mode
+
+## Async import rules
+
+- large imports can be queued as jobs
+- queued imports return a job record immediately
+- final execution state is tracked through the job engine
+- retry handling follows the platform job lifecycle rules
+
+## Operational guidance
+
+- operators should validate before committing large imports
+- failed imports should be reviewed using both validation output and job logs
+- rollback strategy for multi-step imports remains a tracked follow-up issue

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,16 +82,21 @@ nav:
       - Job System Architecture: engineering/job-system-architecture.md
       - Job Lifecycle Model: engineering/job-lifecycle-model.md
       - Worker Model Design: engineering/worker-model-design.md
+      - Import and Export Formats: engineering/import-export-formats.md
+      - Import and Export Validation: engineering/import-export-validation.md
+      - Data Mapping Guidelines: engineering/data-mapping-guidelines.md
   - Operations:
       - Deployment: operations/deployment.md
       - CI/CD: operations/ci-cd.md
       - Database Testing: operations/database-testing.md
       - Media Storage Strategy: operations/media-storage-strategy.md
       - Job Retry and Failure Rules: operations/job-retry-failure-rules.md
+      - Import and Export Error Handling: operations/import-export-error-handling.md
   - API:
       - Overview: api/overview.md
       - Media API: api/media.md
       - Jobs API: api/jobs.md
+      - Import and Export API: api/import-export.md
   - Releases:
       - Release Notes: releases/index.md
   - ADR:
@@ -116,6 +121,7 @@ nav:
       - ADR-0019 Global Navigation Refinement: adr/ADR-0019-global-navigation-refinement.md
       - ADR-0020 Media Asset Management Core Service: adr/ADR-0020-media-asset-management-core-service.md
       - ADR-0021 Job Engine Background Task System: adr/ADR-0021-job-engine-background-task-system.md
+      - ADR-0022 Import Export Framework: adr/ADR-0022-import-export-framework.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document transfer formats, validation, mapping, and error handling
- add import/export API documentation
- add ADR-0022 for the transfer framework

## Validation
- python -m mkdocs build --strict