### PR TITLE
Chunk 21: Document webhooks and integration events

### DIFF
--- a/docs/adr/ADR-0024-webhooks-integration-events.md
+++ b/docs/adr/ADR-0024-webhooks-integration-events.md
@@ -1,0 +1,25 @@
+# ADR-0024: Webhooks and Integration Events
+
+- Status: Accepted
+- Date: 2026-03-27
+
+## Context
+
+InfraLynx needs a platform-level way to notify external systems when important changes occur. The notification model must not depend on UI behavior or inferred state. It also needs to reuse the existing job engine so outbound delivery does not block API mutations.
+
+## Decision
+
+InfraLynx will use an explicit event model backed by stored event records and webhook registrations.
+
+- API write paths emit explicit events.
+- Event records are persisted in `@infralynx/event-core`.
+- Webhook registrations and delivery records are managed by `@infralynx/webhooks`.
+- Matching deliveries are executed asynchronously through `webhook.deliver` jobs.
+- Outbound requests are signed with HMAC SHA-256 using a per-webhook shared secret.
+
+## Consequences
+
+- Event ownership stays clear because only mutation handlers emit events.
+- Delivery is asynchronous and retryable without adding a second worker system.
+- Consumers must tolerate at-least-once delivery behavior.
+- Advanced filtering, backoff policy, and secret-management hardening remain future work.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, and import/export APIs for structured transfer workflows. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
+The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, import/export APIs for structured transfer workflows, and a webhook/events API for outbound integration delivery. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
 
 ## Documentation Rules
 

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -1,0 +1,58 @@
+# Webhooks and Events API
+
+## Endpoints
+
+### `GET /api/webhooks`
+
+Returns registered webhooks and supported event types.
+
+### `POST /api/webhooks`
+
+Registers a webhook.
+
+Example payload:
+
+```json
+{
+  "endpointUrl": "https://example.com/hooks/infralynx",
+  "eventTypes": ["inventory.device.created", "job.created"],
+  "enabled": true
+}
+```
+
+### `GET /api/webhooks/{id}`
+
+Returns the webhook record and recorded deliveries.
+
+### `PUT /api/webhooks/{id}`
+
+Updates endpoint URL, event filters, secret, or enabled state.
+
+### `DELETE /api/webhooks/{id}`
+
+Deletes the webhook registration.
+
+### `GET /api/events`
+
+Lists recorded events. Optional query:
+
+- `type`
+
+### `GET /api/events/{id}`
+
+Returns an event and the delivery attempts associated with it.
+
+## Authorization
+
+Headers required:
+
+- `X-InfraLynx-Actor-Id`
+- `X-InfraLynx-Tenant-Id`
+- `X-InfraLynx-Role-Ids`
+
+## Permissions
+
+- `event:read`
+- `webhook:read`
+- `webhook:write`
+- `webhook:delete`

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -101,6 +101,13 @@ The core platform now also includes a standalone transfer service:
 - import and export endpoints in `apps/api`
 - job-engine-backed asynchronous import for larger payloads
 
+The core platform now also includes an event-driven integration layer:
+
+- explicit event persistence in `@infralynx/event-core`
+- webhook registration and delivery contracts in `@infralynx/webhooks`
+- webhook and event endpoints in `apps/api`
+- job-engine-backed asynchronous webhook delivery in `apps/worker`
+
 The web application now also includes a phase-1 data interaction layer:
 
 - file-backed bootstrap inventory persistence behind API resource contracts

--- a/docs/engineering/event-model.md
+++ b/docs/engineering/event-model.md
@@ -1,0 +1,37 @@
+# Event Model
+
+InfraLynx emits explicit platform events when supported write operations occur. Events are not inferred from reads, polling, or UI behavior.
+
+## Event record
+
+Each event record contains:
+
+- `id`
+- `type`
+- `payload`
+- `created_at`
+
+## Current event families
+
+- `inventory.site.*`
+- `inventory.rack.*`
+- `inventory.device.*`
+- `inventory.prefix.*`
+- `inventory.ip-address.*`
+- `job.created`
+- `webhook.created`
+- `webhook.updated`
+- `webhook.deleted`
+
+## Emission rules
+
+- Events are created only by API write paths.
+- Event payloads include the affected record or identifier.
+- Event records are stored before delivery jobs are queued.
+- Event types stay explicit so subscribers can filter deterministically.
+
+## Ownership
+
+- API mutation handlers decide when an event exists.
+- `@infralynx/event-core` owns the durable event contract.
+- `@infralynx/webhooks` consumes stored events for outbound delivery.

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -13,6 +13,8 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `packages/audit` for audit record contracts
 - `packages/media-core` for media metadata, validation, linking, and access-control helpers
 - `packages/media-storage` for filesystem and future cloud-backed object storage adapters
+- `packages/event-core` for explicit integration event records
+- `packages/webhooks` for webhook configuration and delivery contracts
 - `packages/job-core` for job lifecycle, retry, and job-log contracts
 - `packages/job-queue` for queue abstraction and file-backed queue persistence
 - `packages/domain-core` for core platform boundaries and domain contracts
@@ -142,3 +144,14 @@ Transfer behavior is split across three ownership areas:
 - `apps/api/src/export` for format-aware export endpoints
 
 This keeps transport formats consistent across domains and prevents ad hoc import logic from leaking into runtime services.
+
+## Event And Webhook Layer
+
+Integration events are split across four ownership areas:
+
+- `packages/event-core` for stored event contracts
+- `packages/webhooks` for webhook configuration, filtering, signing, and delivery records
+- `apps/api/src/webhooks` for event and webhook HTTP endpoints plus emission orchestration
+- `apps/worker/src/jobs` for asynchronous webhook delivery execution
+
+This keeps outbound integrations explicit and prevents API request handlers from performing direct remote callbacks.

--- a/docs/engineering/webhook-configuration.md
+++ b/docs/engineering/webhook-configuration.md
@@ -1,0 +1,35 @@
+# Webhook Configuration
+
+Webhooks provide outbound notifications for explicit InfraLynx events.
+
+## Webhook record
+
+Each webhook stores:
+
+- `id`
+- `endpoint_url`
+- `event_types`
+- `secret`
+- `enabled`
+- `created_at`
+- `updated_at`
+
+## Configuration rules
+
+- Endpoint URLs must use `http` or `https`.
+- A webhook must subscribe to at least one event type.
+- Event filters are exact event names, with optional `*` for all supported events.
+- Disabled webhooks stay registered but do not receive delivery jobs.
+
+## Registration flow
+
+1. Client calls `POST /api/webhooks`.
+2. InfraLynx validates the endpoint and filter set.
+3. The webhook is stored.
+4. A `webhook.created` event is emitted.
+5. Matching delivery jobs are queued through the job engine.
+
+## Update and delete
+
+- `PUT /api/webhooks/{id}` updates endpoint URL, filters, secret, or enabled state.
+- `DELETE /api/webhooks/{id}` removes the registration and emits `webhook.deleted`.

--- a/docs/operations/webhook-delivery-guarantees.md
+++ b/docs/operations/webhook-delivery-guarantees.md
@@ -1,0 +1,30 @@
+# Webhook Delivery Guarantees
+
+InfraLynx uses the background job engine to deliver webhooks asynchronously.
+
+## Delivery model
+
+- Event emission stores the event record first.
+- Matching webhooks create `webhook.deliver` jobs.
+- Worker processes lease delivery jobs from the shared queue.
+- Successful deliveries are recorded with response status and timestamp.
+
+## Retry behavior
+
+- Delivery retries use the shared job retry policy.
+- A failed attempt returns the job to `pending` until retries are exhausted.
+- Delivery attempts are recorded separately from job logs.
+- Permanent failure leaves the job in `failed`.
+
+## Current guarantee level
+
+- At-least-once delivery within the bounds of the bootstrap queue implementation.
+- Ordering is best effort and follows queue order, not a global sequencing contract.
+- Duplicate-safe consumers are required because retries can re-deliver the same event.
+
+## Future work
+
+- configurable backoff
+- dead-letter handling
+- alerting and escalation
+- higher-scale queue backends

--- a/docs/operations/webhook-security-model.md
+++ b/docs/operations/webhook-security-model.md
@@ -1,0 +1,32 @@
+# Webhook Security Model
+
+Webhook security is intentionally simple in the bootstrap phase, but the core controls are explicit.
+
+## Current controls
+
+- webhook registration requires RBAC
+- event reading requires RBAC
+- delivery uses per-webhook shared secrets
+- every outbound request includes:
+  - `X-InfraLynx-Event-Id`
+  - `X-InfraLynx-Event-Type`
+  - `X-InfraLynx-Signature-Sha256`
+
+## Signature model
+
+The delivery payload is JSON. InfraLynx computes an HMAC SHA-256 signature from the payload body using the webhook secret.
+
+Consumers should:
+
+1. read the raw request body
+2. compute the same HMAC using the shared secret
+3. compare the result to `X-InfraLynx-Signature-Sha256`
+
+## Known limitations
+
+- secrets are stored as bootstrap platform data, not in a dedicated secret manager
+- there is no IP allowlist model yet
+- there is no replay-prevention token yet
+- token-based outbound auth is deferred
+
+These gaps are tracked as follow-up work, not hidden assumptions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,8 @@ nav:
       - Media System Architecture: engineering/media-system-architecture.md
       - Media Security And Validation: engineering/media-security-validation.md
       - Media Object Association Model: engineering/media-object-association.md
+      - Event Model: engineering/event-model.md
+      - Webhook Configuration: engineering/webhook-configuration.md
       - Job System Architecture: engineering/job-system-architecture.md
       - Job Lifecycle Model: engineering/job-lifecycle-model.md
       - Worker Model Design: engineering/worker-model-design.md
@@ -92,6 +94,8 @@ nav:
       - CI/CD: operations/ci-cd.md
       - Database Testing: operations/database-testing.md
       - Media Storage Strategy: operations/media-storage-strategy.md
+      - Webhook Delivery Guarantees: operations/webhook-delivery-guarantees.md
+      - Webhook Security Model: operations/webhook-security-model.md
       - Job Retry and Failure Rules: operations/job-retry-failure-rules.md
       - Import and Export Error Handling: operations/import-export-error-handling.md
   - API:
@@ -99,6 +103,7 @@ nav:
       - Media API: api/media.md
       - Jobs API: api/jobs.md
       - Import and Export API: api/import-export.md
+      - Webhooks and Events API: api/webhooks.md
   - Releases:
       - Release Notes: releases/index.md
   - ADR:
@@ -125,6 +130,7 @@ nav:
       - ADR-0021 Job Engine Background Task System: adr/ADR-0021-job-engine-background-task-system.md
       - ADR-0022 Import Export Framework: adr/ADR-0022-import-export-framework.md
       - ADR-0023 Data Interaction Layer Phase 1 Navigation: adr/ADR-0023-data-interaction-layer-phase-1-navigation.md
+      - ADR-0024 Webhooks Integration Events: adr/ADR-0024-webhooks-integration-events.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- document the event model, webhook configuration, delivery guarantees, and security model
- add API documentation for webhook and event endpoints
- record ADR-0024 and register the new pages in MkDocs navigation

## Validation
- python -m mkdocs build --strict