### PR TITLE
Document scheduled task system

### DIFF
--- a/docs/adr/ADR-0025-scheduled-task-system.md
+++ b/docs/adr/ADR-0025-scheduled-task-system.md
@@ -1,0 +1,24 @@
+# ADR-0025: Scheduled Task System
+
+## Title
+
+Scheduled Task System
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx needs recurring and time-based triggers for background work, but job execution logic already exists in the job engine. Re-implementing execution behavior in a scheduler would duplicate status, retry, and logging concerns.
+
+## Decision
+
+InfraLynx will store schedules centrally and evaluate them in the worker runtime. The scheduler only enqueues jobs; it does not execute them. The initial scheduler supports UTC-only five-field cron expressions and persists schedule state in a file-backed store aligned with the existing bootstrap adapters.
+
+## Consequences
+
+- scheduling remains independent from job execution
+- retry and failure behavior stay centralized in the job engine
+- schedule persistence survives process restarts
+- timezone handling is intentionally limited in the bootstrap phase

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,7 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, import/export APIs for structured transfer workflows, and a webhook/events API for outbound integration delivery. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
+The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, a scheduler API for recurring trigger definitions, import/export APIs for structured transfer workflows, and a webhook/events API for outbound integration delivery. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
 
 ## Documentation Rules
 

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -1,0 +1,38 @@
+# Scheduler API
+
+The scheduler API manages recurring trigger definitions.
+
+## Endpoints
+
+- `GET /api/schedules`
+- `POST /api/schedules`
+- `GET /api/schedules/{id}`
+- `PUT /api/schedules/{id}`
+- `DELETE /api/schedules/{id}`
+- `GET /api/schedules/logs`
+
+## Required Headers
+
+- `X-InfraLynx-Actor-Id`
+- `X-InfraLynx-Role-Ids`
+- `X-InfraLynx-Tenant-Id` optional, defaults to platform
+
+## Example Create Payload
+
+```json
+{
+  "name": "Daily topology refresh",
+  "cronExpression": "0 6 * * *",
+  "timezone": "UTC",
+  "jobType": "core.echo",
+  "payload": {
+    "message": "scheduled refresh"
+  },
+  "enabled": true
+}
+```
+
+## Access Model
+
+- `schedule:read` for viewing schedules and logs
+- `schedule:write` for create, update, and delete

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -95,6 +95,13 @@ The core platform now also includes a standalone job engine:
 - job creation and status endpoints in `apps/api`
 - asynchronous execution in `apps/worker`
 
+The core platform now also includes a standalone scheduler:
+
+- recurring schedule definitions in `@infralynx/scheduler`
+- schedule CRUD endpoints in `apps/api`
+- worker-side trigger evaluation that enqueues normal jobs
+- centralized schedule state that survives process restarts
+
 The core platform now also includes a standalone transfer service:
 
 - format and schema validation in `@infralynx/data-transfer`

--- a/docs/engineering/cron-syntax-usage.md
+++ b/docs/engineering/cron-syntax-usage.md
@@ -1,0 +1,26 @@
+# Cron Syntax Usage
+
+InfraLynx currently uses a five-field cron format:
+
+`minute hour day-of-month month day-of-week`
+
+Supported patterns in the bootstrap scheduler:
+
+- `*`
+- exact numbers
+- comma-separated values
+- ranges such as `8-18`
+- stepped wildcards such as `*/15`
+- stepped ranges such as `1-10/2`
+
+Examples:
+
+- `0 6 * * *` runs daily at 06:00 UTC
+- `*/15 * * * *` runs every 15 minutes
+- `0 9 * * 1-5` runs weekdays at 09:00 UTC
+
+Unsupported in this chunk:
+
+- named months or weekdays
+- six-field cron with seconds
+- non-UTC schedule execution

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -17,6 +17,7 @@ The `infralynx-platform` repository is a buildable monorepo foundation designed 
 - `packages/webhooks` for webhook configuration and delivery contracts
 - `packages/job-core` for job lifecycle, retry, and job-log contracts
 - `packages/job-queue` for queue abstraction and file-backed queue persistence
+- `packages/scheduler` for recurring schedule definitions, cron parsing, and job-trigger orchestration
 - `packages/domain-core` for core platform boundaries and domain contracts
 - `packages/shared` for reusable utilities with low coupling
 - `tests` for shared testing structure
@@ -134,6 +135,16 @@ Background work is split across four ownership areas:
 - `apps/worker/src/jobs` for asynchronous processing and handler execution
 
 This keeps asynchronous execution separate from request handling and prevents domain packages from owning queue infrastructure.
+
+## Scheduler Layer
+
+Recurring and timed trigger behavior is split across three ownership areas:
+
+- `packages/scheduler` for schedule contracts, cron parsing, next-run calculation, and persisted schedule state
+- `apps/api/src/scheduler` for schedule CRUD and visibility endpoints
+- `apps/worker/src/jobs` for due-schedule evaluation and job enqueueing
+
+This keeps the scheduler focused on trigger creation and leaves execution to the job engine.
 
 ## Import And Export Layer
 

--- a/docs/engineering/scheduling-model.md
+++ b/docs/engineering/scheduling-model.md
@@ -1,0 +1,27 @@
+# Scheduling Model
+
+InfraLynx schedules are trigger definitions, not execution records.
+
+## Core Rule
+
+The scheduler decides when work should start. The job engine performs the work.
+
+## Stored Schedule Shape
+
+- `id`
+- `name`
+- `cron_expression`
+- `job_type`
+- `payload`
+- `enabled`
+- `last_run`
+- `next_run`
+
+## Execution Flow
+
+1. API stores or updates a schedule definition.
+2. Worker evaluates due schedules from centralized state.
+3. Each due schedule enqueues a normal job.
+4. The job engine handles retries, status, and logs.
+
+This keeps scheduling and execution separate and avoids duplicate lifecycle logic.

--- a/docs/operations/scheduler-failure-handling.md
+++ b/docs/operations/scheduler-failure-handling.md
@@ -1,0 +1,22 @@
+# Scheduler Failure Handling
+
+InfraLynx treats scheduling failures and job failures differently.
+
+## Scheduler Responsibility
+
+- persist schedule definitions
+- compute `next_run`
+- enqueue jobs when schedules become due
+
+## Job Engine Responsibility
+
+- execute work
+- retry failed jobs
+- record execution logs
+- expose final job state
+
+## Missed Run Behavior
+
+In the bootstrap model, due schedules are evaluated on worker polling. If the worker is down, the schedule remains due and is enqueued on the next successful poll after restart.
+
+This favors durability over exact-time guarantees and can lead to delayed execution, but not silent loss.

--- a/docs/operations/scheduler-timezone-handling.md
+++ b/docs/operations/scheduler-timezone-handling.md
@@ -1,0 +1,22 @@
+# Scheduler Timezone Handling
+
+The bootstrap scheduler stores schedules centrally but executes them in `UTC` only.
+
+## Why
+
+UTC-only scheduling removes ambiguity while the platform is still establishing its core job and event model.
+
+## Current Behavior
+
+- API accepts `timezone`
+- scheduler validates and currently permits `UTC` only
+- `next_run` is computed from UTC timestamps
+- worker comparisons are performed against UTC ISO timestamps
+
+## Future Expansion
+
+Later work should introduce:
+
+- named IANA timezone support
+- daylight-saving-safe next-run calculation
+- schedule preview and drift diagnostics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,8 @@ nav:
       - Webhook Configuration: engineering/webhook-configuration.md
       - Job System Architecture: engineering/job-system-architecture.md
       - Job Lifecycle Model: engineering/job-lifecycle-model.md
+      - Scheduling Model: engineering/scheduling-model.md
+      - Cron Syntax Usage: engineering/cron-syntax-usage.md
       - Worker Model Design: engineering/worker-model-design.md
       - Import and Export Formats: engineering/import-export-formats.md
       - Import and Export Validation: engineering/import-export-validation.md
@@ -97,11 +99,14 @@ nav:
       - Webhook Delivery Guarantees: operations/webhook-delivery-guarantees.md
       - Webhook Security Model: operations/webhook-security-model.md
       - Job Retry and Failure Rules: operations/job-retry-failure-rules.md
+      - Scheduler Timezone Handling: operations/scheduler-timezone-handling.md
+      - Scheduler Failure Handling: operations/scheduler-failure-handling.md
       - Import and Export Error Handling: operations/import-export-error-handling.md
   - API:
       - Overview: api/overview.md
       - Media API: api/media.md
       - Jobs API: api/jobs.md
+      - Scheduler API: api/scheduler.md
       - Import and Export API: api/import-export.md
       - Webhooks and Events API: api/webhooks.md
   - Releases:
@@ -136,6 +141,7 @@ nav:
       - ADR-0022 Import Export Framework: adr/ADR-0022-import-export-framework.md
       - ADR-0023 Data Interaction Layer Phase 1 Navigation: adr/ADR-0023-data-interaction-layer-phase-1-navigation.md
       - ADR-0024 Webhooks Integration Events: adr/ADR-0024-webhooks-integration-events.md
+      - ADR-0025 Scheduled Task System: adr/ADR-0025-scheduled-task-system.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- add scheduling model, cron syntax, timezone, and failure-handling docs
- add scheduler API documentation
- record ADR-0025 for the scheduled task system