### PR TITLE
Chunk 22.5: document platform library standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [v0.3.0-alpha]
+
+### Added
+- External library usage policy, service abstraction design guidance, dependency alignment documentation, and ADR-0027 for platform standardization.
+
+### Changed
+- Updated the documentation release baseline to `v0.3.0-alpha`.
+- Extended architecture guidance to reflect BullMQ, node-cron, axios, multer, React Flow, and the standardized auth-provider library set.
+
+### Fixed
+- Clarified that infrastructure concerns must be wrapped behind InfraLynx-owned service layers instead of leaking library details into domain logic.
+
+### Removed
+- None.
+
 ## [v0.2.0-alpha]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs Build](https://github.com/Super8Four/infralynx-docs/actions/workflows/docs-build.yml/badge.svg?style=flat-square)](https://github.com/Super8Four/infralynx-docs/actions/workflows/docs-build.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.1.0--alpha-E6E1D9?style=flat-square&labelColor=2A3F5F)](VERSION)
+[![Version](https://img.shields.io/badge/version-v0.3.0--alpha-E6E1D9?style=flat-square&labelColor=2A3F5F)](VERSION)
 [![MkDocs](https://img.shields.io/badge/MkDocs-Material-526CFE?style=flat-square&logo=materialformkdocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
 [![Site](https://img.shields.io/badge/site-GitHub%20Pages-222222?style=flat-square&logo=githubpages&logoColor=white)](https://super8four.github.io/infralynx-docs/)
 
@@ -22,7 +22,7 @@ InfraLynx documentation is version-aware and organized by audience and operating
 
 ## Versioning
 
-This repository follows Semantic Versioning and currently tracks [v0.1.0-alpha](VERSION). Internal progress metadata such as `v0.1.0-alpha+chunk21` may be used in release notes and internal coordination without changing version precedence.
+This repository follows Semantic Versioning and currently tracks [v0.3.0-alpha](VERSION). Internal progress metadata such as `v0.3.0-alpha+chunk22.5` may be used in release notes and internal coordination without changing version precedence.
 
 ## License
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.2.0-alpha
+v0.3.0-alpha

--- a/docs/adr/ADR-0027-platform-standardization-library-alignment.md
+++ b/docs/adr/ADR-0027-platform-standardization-library-alignment.md
@@ -13,7 +13,7 @@ InfraLynx will standardize on wrapped third-party libraries for non-core infrast
 
 - `openid-client` for OIDC
 - `ldapjs` for LDAP
-- `passport-saml` for SAML
+- `@node-saml/node-saml` for SAML, used as the maintained equivalent to legacy `passport-saml`
 - `bcrypt` for password hashing
 - `bullmq` for async job execution
 - `node-cron` for recurring schedule triggers

--- a/docs/adr/ADR-0027-platform-standardization-library-alignment.md
+++ b/docs/adr/ADR-0027-platform-standardization-library-alignment.md
@@ -1,0 +1,30 @@
+# ADR-0027: Platform Standardization Library Alignment
+
+- Status: Accepted
+- Date: 2026-03-27
+
+## Context
+
+InfraLynx had accumulated several custom infrastructure implementations for concerns that are already solved well by established libraries. That increased maintenance cost and created avoidable operational risk.
+
+## Decision
+
+InfraLynx will standardize on wrapped third-party libraries for non-core infrastructure concerns:
+
+- `openid-client` for OIDC
+- `ldapjs` for LDAP
+- `passport-saml` for SAML
+- `bcrypt` for password hashing
+- `bullmq` for async job execution
+- `node-cron` for recurring schedule triggers
+- `axios` for outbound webhook delivery
+- `multer` for upload parsing
+- `reactflow` for topology graph rendering
+
+These libraries must stay behind InfraLynx-owned abstractions so domain logic, records, and UI contracts remain stable.
+
+## Consequences
+
+- The platform reduces custom infrastructure code and aligns with production-grade libraries.
+- Some selected libraries introduce lifecycle risk of their own and may need future replacement, especially where upstream maintenance is weak.
+- InfraLynx retains portability because application code depends on internal abstractions rather than direct vendor APIs.

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -8,7 +8,7 @@ InfraLynx uses Semantic Versioning for all public releases:
 
 ## Current Baseline
 
-The current baseline is `v0.2.0-alpha`.
+The current baseline is `v0.3.0-alpha`.
 
 ## Pre-release Tags
 
@@ -20,8 +20,8 @@ The current baseline is `v0.2.0-alpha`.
 
 InfraLynx may append optional internal metadata for progress tracking, for example:
 
-- `v0.2.0-alpha+chunk23`
-- `v0.2.0-alpha+chunk23.5`
+- `v0.3.0-alpha+chunk22.5`
+- `v0.3.0-alpha+chunk23`
 
 This metadata does not change version precedence. It is used for internal build identification, chunk tracking, and release coordination.
 

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -102,6 +102,17 @@ The core platform now also includes a standalone scheduler:
 - worker-side trigger evaluation that enqueues normal jobs
 - centralized schedule state that survives process restarts
 
+The infrastructure layer is now standardized around wrapped third-party libraries:
+
+- `openid-client`, `ldapjs`, `passport-saml`, and `bcrypt` for authentication concerns
+- `bullmq` for background queue execution
+- `node-cron` for recurring triggers
+- `axios` for outbound webhook delivery
+- `multer` for upload parsing
+- `reactflow` for topology graph rendering
+
+These libraries are used behind InfraLynx-owned abstractions so domain packages and UI contracts do not depend directly on vendor-specific APIs.
+
 The core platform now also includes a standalone transfer service:
 
 - format and schema validation in `@infralynx/data-transfer`

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -104,7 +104,7 @@ The core platform now also includes a standalone scheduler:
 
 The infrastructure layer is now standardized around wrapped third-party libraries:
 
-- `openid-client`, `ldapjs`, `passport-saml`, and `bcrypt` for authentication concerns
+- `openid-client`, `ldapjs`, `@node-saml/node-saml`, and `bcrypt` for authentication concerns
 - `bullmq` for background queue execution
 - `node-cron` for recurring triggers
 - `axios` for outbound webhook delivery

--- a/docs/engineering/dependency-documentation.md
+++ b/docs/engineering/dependency-documentation.md
@@ -6,7 +6,7 @@ Chunk 22.5 standardized the platform around wrapped external libraries for infra
 
 - `openid-client` for OIDC flows
 - `ldapjs` for LDAP and Active Directory connectivity
-- `passport-saml` for SAML request and response handling
+- `@node-saml/node-saml` for SAML request and response handling
 - `bcrypt` for password hashing
 - `jose` retained for JWT session handling
 

--- a/docs/engineering/dependency-documentation.md
+++ b/docs/engineering/dependency-documentation.md
@@ -1,0 +1,33 @@
+# Dependency Documentation
+
+Chunk 22.5 standardized the platform around wrapped external libraries for infrastructure concerns.
+
+## Auth
+
+- `openid-client` for OIDC flows
+- `ldapjs` for LDAP and Active Directory connectivity
+- `passport-saml` for SAML request and response handling
+- `bcrypt` for password hashing
+- `jose` retained for JWT session handling
+
+## Background Processing
+
+- `bullmq` for async jobs, retries, delays, and concurrency
+- `ioredis` for Redis connectivity
+- `ioredis-mock` for local-compatible BullMQ development and test flows
+- `node-cron` for recurring schedule triggers
+
+## Integration and Media
+
+- `axios` for outbound webhook delivery
+- `multer` for multipart upload parsing
+
+## UI
+
+- `reactflow` for topology graph rendering
+
+## Dependency Governance Notes
+
+- Libraries are used only through InfraLynx-owned packages or runtime adapters.
+- Replacements must update documentation, changelog, and versioning together.
+- Dependency choice does not override InfraLynx data models or domain boundaries.

--- a/docs/engineering/external-library-usage-policy.md
+++ b/docs/engineering/external-library-usage-policy.md
@@ -1,0 +1,35 @@
+# External Library Usage Policy
+
+InfraLynx uses external libraries for solved infrastructure problems and keeps custom code focused on domain modeling, orchestration, and product behavior.
+
+## Policy Rules
+
+- Use established libraries for authentication protocols, queues, scheduling, HTTP delivery, upload parsing, and graph rendering.
+- Keep all library usage behind InfraLynx-owned service layers or adapters.
+- Do not import infrastructure libraries directly into domain packages unless the package is the abstraction boundary for that concern.
+- Prefer replaceable wrappers over vendor-specific coupling in application code.
+
+## Current Standardized Libraries
+
+- OIDC: `openid-client`
+- LDAP: `ldapjs`
+- SAML: `passport-saml`
+- Password hashing: `bcrypt`
+- Jobs: `bullmq`
+- Scheduling: `node-cron`
+- Webhook HTTP delivery: `axios`
+- Media upload parsing: `multer`
+- Topology graph rendering: `reactflow`
+
+## Replacement Boundary
+
+External libraries may change over time. The stable contract for the rest of the platform is:
+
+- provider abstractions in `packages/auth-providers/*`
+- queue abstractions in `packages/job-queue`
+- schedule abstractions in `packages/scheduler`
+- delivery abstractions in `packages/webhooks`
+- upload and storage abstractions in `packages/media-*`
+- rendering contracts in `packages/ui` plus `packages/network-domain`
+
+That boundary keeps domain logic stable even when infrastructure dependencies change.

--- a/docs/engineering/external-library-usage-policy.md
+++ b/docs/engineering/external-library-usage-policy.md
@@ -13,7 +13,7 @@ InfraLynx uses external libraries for solved infrastructure problems and keeps c
 
 - OIDC: `openid-client`
 - LDAP: `ldapjs`
-- SAML: `passport-saml`
+- SAML: `@node-saml/node-saml` as the maintained equivalent to older `passport-saml` guidance
 - Password hashing: `bcrypt`
 - Jobs: `bullmq`
 - Scheduling: `node-cron`

--- a/docs/engineering/service-abstraction-design.md
+++ b/docs/engineering/service-abstraction-design.md
@@ -1,0 +1,32 @@
+# Service Abstraction Design
+
+InfraLynx wraps external libraries behind internal service boundaries so infrastructure dependencies do not leak into domain logic.
+
+## Design Rules
+
+- Domain packages define business contracts and validation rules.
+- Infrastructure packages own library integration details.
+- API and worker runtimes depend on InfraLynx abstractions, not directly on vendor APIs where avoidable.
+- External configuration stays in InfraLynx records and service inputs rather than hard-coded library setup files.
+
+## Standardized Boundaries
+
+- `@infralynx/auth-core` and `@infralynx/auth-providers/*`
+  Library-backed auth providers with shared provider records and session flows.
+- `@infralynx/job-core` and `@infralynx/job-queue`
+  BullMQ-backed queue execution with InfraLynx job metadata and logs.
+- `@infralynx/scheduler`
+  Schedule persistence plus cron-backed trigger orchestration.
+- `@infralynx/webhooks`
+  Event matching, signing, delivery records, and axios-backed outbound delivery.
+- `@infralynx/media-core` and `@infralynx/media-storage`
+  Metadata, linking, validation, upload parsing, and storage adapters.
+- `@infralynx/ui` with `@infralynx/network-domain`
+  Stable topology view contracts with React Flow only in the rendering layer.
+
+## Anti-Patterns
+
+- embedding library types in domain records
+- passing raw vendor clients through domain services
+- storing provider config in environment files when the product requires UI management
+- making UI components responsible for infrastructure protocol behavior

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,9 @@ nav:
       - Core Domain Architecture: engineering/core-domain-architecture.md
       - Authentication Model: engineering/auth-model.md
       - Authentication Architecture: engineering/authentication-architecture.md
+      - External Library Usage Policy: engineering/external-library-usage-policy.md
+      - Service Abstraction Design: engineering/service-abstraction-design.md
+      - Dependency Documentation: engineering/dependency-documentation.md
       - Provider Configuration Guide: engineering/provider-configuration-guide.md
       - RBAC Model: engineering/rbac-model.md
       - IPAM Data Model: engineering/ipam-data-model.md
@@ -150,6 +153,7 @@ nav:
       - ADR-0024 Webhooks Integration Events: adr/ADR-0024-webhooks-integration-events.md
       - ADR-0025 Scheduled Task System: adr/ADR-0025-scheduled-task-system.md
       - ADR-0026 Authentication System Multi Provider: adr/ADR-0026-authentication-system-multi-provider.md
+      - ADR-0027 Platform Standardization Library Alignment: adr/ADR-0027-platform-standardization-library-alignment.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- add the external library usage policy, service abstraction design, dependency documentation, and ADR-0027
- update architecture, versioning guidance, README, and changelog for v0.3.0-alpha
- document InfraLynx compliance with the external library replacement policy

## Validation
- python -m mkdocs build --strict