### PR TITLE
Chunks 31.1 and 32: repo presentation and API versioning docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [v0.12.0-alpha+chunk31.1]
+
+### Added
+- Repository presentation, onboarding, and ecosystem navigation documentation.
+
+### Changed
+- Standardized README presentation across InfraLynx repositories and updated the documentation navigation to reflect repository ecosystem onboarding.
+
+### Fixed
+- Clarified how contributors navigate the full InfraLynx repository landscape from docs-first entry points.
+
+### Removed
+- None.
+
+## [v0.12.0-alpha]
+
+### Added
+- API versioning, deprecation policy, error model, and ADR-0036 documentation.
+
+### Changed
+- Updated the documentation release baseline to `v0.12.0-alpha`.
+- Expanded API guidance to standardize `/api/v1`, contract validation, and legacy-route deprecation behavior.
+
+### Fixed
+- Clarified how InfraLynx preserves backward compatibility while hardening request and response contracts for external integrations.
+
+### Removed
+- None.
+
 ## [v0.11.0-alpha]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,37 +2,112 @@
 
 [![Docs Build](https://github.com/Super8Four/infralynx-docs/actions/workflows/docs-build.yml/badge.svg?style=flat-square)](https://github.com/Super8Four/infralynx-docs/actions/workflows/docs-build.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.3.0--alpha-E6E1D9?style=flat-square&labelColor=2A3F5F)](VERSION)
-[![MkDocs](https://img.shields.io/badge/MkDocs-Material-526CFE?style=flat-square&logo=materialformkdocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
-[![Site](https://img.shields.io/badge/site-GitHub%20Pages-222222?style=flat-square&logo=githubpages&logoColor=white)](https://super8four.github.io/infralynx-docs/)
+[![Version](https://img.shields.io/badge/version-v0.12.0--alpha%2Bchunk31.1-E6E1D9?style=flat-square&labelColor=2A3F5F)](VERSION)
+[![Node.js](https://img.shields.io/badge/Node.js-24-5FA04E?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-supported-336791?style=flat-square&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![MS%20SQL%20Server](https://img.shields.io/badge/MS%20SQL%20Server-supported-CC2927?style=flat-square&logo=microsoftsqlserver&logoColor=white)](https://www.microsoft.com/sql-server/)
+[![MariaDB](https://img.shields.io/badge/MariaDB-supported-003545?style=flat-square&logo=mariadb&logoColor=white)](https://mariadb.org/)
+[![Documentation](https://img.shields.io/badge/docs-MkDocs-526CFE?style=flat-square&logo=materialformkdocs&logoColor=white)](https://super8four.github.io/infralynx-docs/)
 
-InfraLynx documentation is version-aware and organized by audience and operating concern.
+Official documentation, standards, architecture, and deployment guides for InfraLynx.
 
-## Structure
+Quick Links: [Documentation Site](https://super8four.github.io/infralynx-docs/) | [Platform Repo](https://github.com/Super8Four/infralynx-platform) | [Docs Repo](https://github.com/Super8Four/infralynx-docs) | [Standards Repo](https://github.com/Super8Four/infralynx-standards) | [Design Repo](https://github.com/Super8Four/infralynx-design) | [Infra Repo](https://github.com/Super8Four/infralynx-infra)
 
-- `product/`
-- `engineering/`
-- `operations/`
-- `api/`
-- `adr/`
-- `design/`
-- `development/`
-- `legal/`
-- `releases/`
+## Overview
 
-## Versioning
+`infralynx-docs` is the canonical written source for InfraLynx architecture, operations, API contracts, governance, release notes, legal position, and contributor onboarding. It explains how the platform works and how the rest of the repository ecosystem fits together.
 
-This repository follows Semantic Versioning and currently tracks [v0.3.0-alpha](VERSION). Internal progress metadata such as `v0.3.0-alpha+chunk22.5` may be used in release notes and internal coordination without changing version precedence.
+## Current Status
+
+- Repository version: `v0.12.0-alpha+chunk31.1`
+- Program snapshot: `v0.1.0-alpha+chunk31`
+- Current chunk: `31.1`
+- Current phase: `Scale / Reliability`
+- Next milestone: `Chunk 32 -> API Versioning`
+- Target release: `v1.0.0`
+
+The docs repo tracks the active platform build and is maintained as a first-class product artifact, not a secondary export.
+
+## Roadmap Progress
+
+Completed:
+- Core platform
+- IPAM
+- DCIM
+- Operations
+- Security
+- Performance
+
+In Progress:
+- Reliability / API hardening
+
+Upcoming:
+- Product differentiators
+- Visual subnet planning
+- Network containers
+- AI integrations
+
+## Tech Stack
+
+- Markdown and MkDocs Material
+- GitHub Pages publishing
+- InfraLynx architecture, API, and operations source material
+- Cross-repo governance and ADR documentation
+
+## Getting Started
+
+1. Install MkDocs dependencies in your environment.
+2. From this repo, build the site:
+
+```powershell
+python -m mkdocs build --strict
+```
+
+3. Serve locally if needed:
+
+```powershell
+python -m mkdocs serve
+```
+
+## Documentation Links
+
+- [Published Site](https://super8four.github.io/infralynx-docs/)
+- [Repository Map](https://super8four.github.io/infralynx-docs/engineering/platform-repository/)
+- [Onboarding Guide](https://super8four.github.io/infralynx-docs/development/onboarding/)
+- [Versioning Strategy](https://super8four.github.io/infralynx-docs/development/versioning/)
+- [Contributing Guide](CONTRIBUTING.md)
+
+## InfraLynx Repository Ecosystem
+
+- [infralynx-platform](https://github.com/Super8Four/infralynx-platform): runtime application code and shared packages
+- [infralynx-docs](https://github.com/Super8Four/infralynx-docs): official written reference for the platform
+- [infralynx-infra](https://github.com/Super8Four/infralynx-infra): infrastructure-as-code and deployment configuration
+- [infralynx-standards](https://github.com/Super8Four/infralynx-standards): governance and contributor standards
+- [infralynx-design](https://github.com/Super8Four/infralynx-design): design system direction and visual assets
+
+## Contribution Guidelines
+
+Documentation changes should land with the behavior or policy changes they describe whenever possible. Use [CONTRIBUTING.md](CONTRIBUTING.md) and the standards repo as the operating baseline.
+
+## Support InfraLynx
+
+Support continued development of InfraLynx:
+
+[https://buymeacoffee.com/infralynx](https://buymeacoffee.com/infralynx)
+
+Support helps fund:
+- New features
+- Documentation
+- Hosted services
+- Enterprise integrations
 
 ## License
 
 This repository is licensed under Apache 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-## Project Files
+## Support / Community
 
-- [CHANGELOG.md](CHANGELOG.md)
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [CLA.md](CLA.md)
-- [SECURITY.md](SECURITY.md)
-- [SUPPORT.md](SUPPORT.md)
-- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [Published Docs](https://super8four.github.io/infralynx-docs/)
+- [Support Policy](SUPPORT.md)
+- [Security Policy](SECURITY.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.11.0-alpha
+v0.12.0-alpha+chunk31.1

--- a/docs/adr/ADR-0036-api-versioning-contract-hardening.md
+++ b/docs/adr/ADR-0036-api-versioning-contract-hardening.md
@@ -1,0 +1,31 @@
+# ADR-0036: API Versioning and Contract Hardening
+
+## Status
+
+Accepted
+
+## Context
+
+InfraLynx had accumulated a growing API surface without a stable namespace, centralized schema validation, or a consistent versioned error model. That was acceptable during early scaffolding but not for long-term integrations.
+
+## Decision
+
+InfraLynx will:
+
+- treat `/api/v1` as the stable integration namespace
+- validate versioned requests centrally with Zod
+- normalize versioned JSON responses to include shared metadata
+- preserve legacy `/api/*` routes temporarily with explicit deprecation signaling
+
+## Consequences
+
+Positive:
+
+- external integrations get a stable namespace
+- request validation is consistent across the primary API surface
+- deprecation becomes explicit rather than implicit
+
+Tradeoffs:
+
+- legacy and versioned routes must coexist for a migration window
+- response normalization adds a small amount of API-layer indirection

--- a/docs/api/deprecation-policy.md
+++ b/docs/api/deprecation-policy.md
@@ -1,0 +1,22 @@
+# API Deprecation Policy
+
+InfraLynx uses explicit deprecation signals before removing API behavior.
+
+## Current Policy
+
+- `/api/v1/*` is the active namespace.
+- Legacy `/api/*` routes are deprecated compatibility routes.
+- Deprecated routes emit deprecation headers and point to this policy.
+
+## Deprecation Process
+
+1. Mark the route or field as deprecated in documentation.
+2. Emit deprecation signaling in the API response headers.
+3. Preserve a migration window long enough for known consumers to move.
+4. Remove the deprecated behavior only in a later versioned API change.
+
+## Integration Expectations
+
+- Consumers should migrate to `/api/v1/*` immediately.
+- New consumers should never start on deprecated `/api/*` routes.
+- Deprecated compatibility routes may continue to function, but they should not receive new features.

--- a/docs/api/error-model.md
+++ b/docs/api/error-model.md
@@ -1,0 +1,42 @@
+# API Error Model
+
+InfraLynx versioned endpoints use a standardized JSON error envelope.
+
+## Shape
+
+```json
+{
+  "error": {
+    "code": "invalid_body",
+    "message": "request body failed validation",
+    "details": {}
+  },
+  "meta": {
+    "apiVersion": "v1",
+    "deprecated": false
+  }
+}
+```
+
+## Required Fields
+
+- `error.code`: stable machine-readable classification
+- `error.message`: human-readable summary
+- `meta.apiVersion`: current API namespace
+- `meta.deprecated`: deprecation marker for the response contract
+
+## Typical Error Codes
+
+- `invalid_json`
+- `invalid_query`
+- `invalid_body`
+- `not_found`
+- `forbidden`
+- `unauthorized`
+- `response_contract_violation`
+
+## Guidance
+
+- Clients should branch on `error.code`, not `error.message`.
+- Validation failures may include structured `details`.
+- Server-side contract failures should be treated as platform defects, not user input problems.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -14,7 +14,16 @@ API documentation should be organized by:
 
 ## Current Status
 
-The API surface now includes baseline read endpoints for shell-facing data, a standalone media API for upload and retrieval, a jobs API for asynchronous background execution, a scheduler API for recurring trigger definitions, a backup API for recovery workflows, a cache-status API for performance visibility, import/export APIs for structured transfer workflows, and a webhook/events API for outbound integration delivery. Documentation is still growing by subsystem, but the framework is now paired with active contracts.
+The InfraLynx API now treats `/api/v1` as the stable integration namespace. Legacy `/api/*` routes remain temporarily available for compatibility, but they are marked as deprecated and documented under the formal deprecation policy.
+
+The API surface includes baseline read endpoints for shell-facing data, media upload and retrieval, jobs, scheduler definitions, backup workflows, cache visibility, import and export operations, validation, workflows, audit access, and webhook or event integration delivery.
+
+## Versioning Baseline
+
+- Use `/api/v1/*` for all new integrations.
+- Expect standardized JSON metadata on versioned responses.
+- Expect standardized error envelopes on versioned failures.
+- Treat legacy `/api/*` routes as compatibility-only paths pending retirement.
 
 ## Documentation Rules
 

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,32 @@
+# API Versioning
+
+InfraLynx exposes versioned API contracts under `/api/v1`.
+
+## Rules
+
+- All new integrations must target `/api/v1`.
+- Contract changes that break compatibility require a new major API namespace.
+- Backward-compatible additions may ship within the active version.
+- Legacy unversioned `/api/*` routes are compatibility shims only.
+
+## Response Metadata
+
+Versioned JSON responses include a `meta` object:
+
+```json
+{
+  "meta": {
+    "apiVersion": "v1",
+    "deprecated": false
+  }
+}
+```
+
+This metadata is appended consistently so clients can distinguish stable versioned responses from legacy compatibility traffic.
+
+## Compatibility Expectations
+
+- New fields may be added to JSON responses in a backward-compatible way.
+- Existing field semantics must not change without a version bump.
+- Request validation is enforced before handlers run on versioned routes.
+- Legacy routes may emit deprecation headers before removal.

--- a/docs/development/onboarding.md
+++ b/docs/development/onboarding.md
@@ -1,0 +1,39 @@
+# Contributor Onboarding
+
+This guide explains how to approach InfraLynx as a contributor without guessing where things live.
+
+## Start Here
+
+1. Read the repository README for the repo you are entering.
+2. Review the standards repository for contribution and governance expectations.
+3. Use this docs repository to understand architecture, APIs, operations, and ADR history.
+4. Make changes in the repository that owns the concern rather than adding cross-cutting drift.
+
+## Repository Selection
+
+- Use `infralynx-platform` for runtime code, APIs, workers, UI, migrations, and tests.
+- Use `infralynx-docs` for architecture, release, operations, and API documentation.
+- Use `infralynx-infra` for deployment, hosting, and infrastructure-as-code.
+- Use `infralynx-standards` for governance, templates, and contributor policy.
+- Use `infralynx-design` for design-system direction, UX guidance, and shared assets.
+
+## Working Expectations
+
+- Keep changes scoped.
+- Update docs with behavior or policy changes.
+- Add or update ADRs when architectural decisions change.
+- Preserve InfraLynx service abstractions and avoid leaking library-specific logic outside infrastructure layers.
+- Treat lint, typecheck, test, build, and docs validation as the normal merge baseline.
+
+## Program Snapshot
+
+- Program snapshot: `v0.1.0-alpha+chunk31`
+- Current phase: `Scale / Reliability`
+- Next milestone: `Chunk 32 -> API Versioning`
+- Target release: `v1.0.0`
+
+## Helpful Links
+
+- [Repository Map](../engineering/platform-repository.md)
+- [Versioning Strategy](versioning.md)
+- [Contributing Guide](../contributing.md)

--- a/docs/engineering/platform-repository.md
+++ b/docs/engineering/platform-repository.md
@@ -1,5 +1,25 @@
 # Platform Repository Structure
 
+InfraLynx is intentionally split across a small repository ecosystem so runtime code, documentation, governance, design direction, and infrastructure concerns can evolve without collapsing into a single unstructured repository.
+
+## Repository Ecosystem
+
+- `infralynx-platform` for the runtime application, UI, API, worker, shared packages, tests, and migrations
+- `infralynx-docs` for architecture, API, operations, ADRs, onboarding, and public-facing written guidance
+- `infralynx-infra` for infrastructure-as-code, deployment pipelines, and hosting configuration
+- `infralynx-standards` for governance, contribution policy, templates, and development rules
+- `infralynx-design` for UI and UX standards, branding, design-system direction, and shared visual assets
+
+## Current Program Status
+
+- Program snapshot: `v0.1.0-alpha+chunk31`
+- Current chunk: `31.1`
+- Current phase: `Scale / Reliability`
+- Next milestone: `Chunk 32 -> API Versioning`
+- Target release: `v1.0.0`
+
+## Platform Monorepo
+
 The `infralynx-platform` repository is a buildable monorepo foundation designed to keep runtime concerns, shared packages, migrations, and deployment-facing assets separated from the start.
 
 ## Structure Overview

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,9 @@ nav:
       - Approval Lifecycle: operations/approval-lifecycle.md
   - API:
       - Overview: api/overview.md
+      - API Versioning: api/versioning.md
+      - API Error Model: api/error-model.md
+      - API Deprecation Policy: api/deprecation-policy.md
       - Authentication API: api/authentication.md
       - Media API: api/media.md
       - Jobs API: api/jobs.md
@@ -151,6 +154,7 @@ nav:
   - Releases:
       - Release Notes: releases/index.md
   - Development:
+      - Onboarding Guide: development/onboarding.md
       - Versioning Strategy: development/versioning.md
   - Legal:
       - Licensing: legal/licensing.md
@@ -191,6 +195,7 @@ nav:
       - ADR-0033 Caching Performance Layer: adr/ADR-0033-caching-performance-layer.md
       - ADR-0034 Query Optimization Index Strategy: adr/ADR-0034-query-optimization-index-strategy.md
       - ADR-0035 Load Testing Stability Validation: adr/ADR-0035-load-testing-stability-validation.md
+      - ADR-0036 API Versioning Contract Hardening: adr/ADR-0036-api-versioning-contract-hardening.md
   - Design:
       - Branding: design/branding.md
       - UX Principles: design/ux-principles.md


### PR DESCRIPTION
## Summary
- standardize docs repository presentation sections and ecosystem navigation
- add Chunk 32 API versioning, deprecation, and error model documentation
- update onboarding and repository map references

## Validation
- python -m mkdocs build --strict